### PR TITLE
Test mariadb compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,8 +13,8 @@ jobs:
         os:
           # Use ubuntu-18.04 instead of ubuntu-20.04 temporarily, due to a failing test on mysql 8.0.
           # https://github.com/brianmario/mysql2/issues/1165
-          # - ubuntu-20.04 # focal
-          - ubuntu-18.04 # bionic
+          - ubuntu-20.04 # focal
+          # - ubuntu-18.04 # bionic
         ruby:
           - '3.1'
           - '3.0'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,13 @@ jobs:
           # Comment out due to ci/setup.sh stucking.
           # - {os: ubuntu-18.04, ruby: 2.4, db: mariadb10.1}
           # Allow failure due to the issue #965, #1165.
-          - {os: ubuntu-20.04, ruby: '2.4', db: mariadb10.3, allow-failure: true}
+          - {os: ubuntu-20.04, ruby: '2.7', db: mariadb10.3, allow-failure: false}
+          - {os: ubuntu-20.04, ruby: '2.7', db: mariadb10.4, allow-failure: true}
+          - {os: ubuntu-20.04, ruby: '2.7', db: mariadb10.5, allow-failure: true}
+          - {os: ubuntu-20.04, ruby: '2.7', db: mariadb10.6, allow-failure: true}
+          - {os: ubuntu-20.04, ruby: '2.7', db: mariadb10.7, allow-failure: true}
+          - {os: ubuntu-20.04, ruby: '2.7', db: mariadb10.8, allow-failure: true}
+          - {os: ubuntu-20.04, ruby: '2.7', db: mariadb10.9, allow-failure: true}
           - {os: ubuntu-18.04, ruby: '2.4', db: mysql57}
           # Allow failure due to the issue #1165.
           - {os: ubuntu-20.04, ruby: '2.4', db: mysql80, allow-failure: true}

--- a/ci/setup.sh
+++ b/ci/setup.sh
@@ -44,40 +44,16 @@ if [[ -n ${DB-} && x$DB =~ ^xmysql80 ]]; then
   CHANGED_PASSWORD=true
 fi
 
-# Install MariaDB client headers after Travis CI fix for MariaDB 10.2 broke earlier 10.x
-if [[ -n ${DB-} && x$DB =~ ^xmariadb10.0 ]]; then
-  if [[ -n ${GITHUB_ACTIONS-} ]]; then
-    sudo apt-get install -y -o Dpkg::Options::='--force-confnew' mariadb-server mariadb-server-10.0 libmariadb2
-    CHANGED_PASSWORD_BY_RECREATE=true
-  else
-    sudo apt-get install -y -o Dpkg::Options::='--force-confnew' libmariadbclient-dev
-  fi
-fi
-
-# Install MariaDB client headers after Travis CI fix for MariaDB 10.2 broke earlier 10.x
-if [[ -n ${DB-} && x$DB =~ ^xmariadb10.1 ]]; then
-  if [[ -n ${GITHUB_ACTIONS-} ]]; then
-    sudo apt-get install -y -o Dpkg::Options::='--force-confnew' mariadb-server mariadb-server-10.1 libmariadb-dev
-    CHANGED_PASSWORD_BY_RECREATE=true
-  else
-    sudo apt-get install -y -o Dpkg::Options::='--force-confnew' libmariadbclient-dev
-  fi
-fi
-
-# Install MariaDB 10.2 if DB=mariadb10.2
-# NOTE this is a workaround until Travis CI merges a fix to its mariadb addon.
-if [[ -n ${DB-} && x$DB =~ ^xmariadb10.2 ]]; then
-  sudo apt-get install -y -o Dpkg::Options::='--force-confnew' mariadb-server mariadb-server-10.2 libmariadbclient18
-fi
-
-# Install MariaDB 10.3 if DB=mariadb10.3
-if [[ -n ${GITHUB_ACTIONS-} && -n ${DB-} && x$DB =~ ^xmariadb10.3 ]]; then
+# Install MariaDB
+if [[ -n ${GITHUB_ACTIONS-} && -n ${DB-} && x$DB =~ ^xmariadb ]]; then
+  echo "purging mysql, installing ${DB}"
+  minor_version=${DB#*.}
   sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
   sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
   sudo apt-get purge -y 'mysql-common*' 'mysql-client*' 'mysql-server*'
   sudo mv /etc/mysql "/etc/mysql-$(date +%Y%m%d-%H%M%S)"
   sudo mv /var/lib/mysql "/var/lib/mysql-$(date +%Y%m%d-%H%M%S)"
-  sudo apt-get install -y -o Dpkg::Options::='--force-confnew' mariadb-server mariadb-server-10.3 libmariadb-dev
+  sudo apt-get install -y -o Dpkg::Options::='--force-confnew' mariadb-server mariadb-server-10.${minor_version} libmariadb-dev
   CHANGED_PASSWORD_BY_RECREATE=true
 fi
 

--- a/ci/setup.sh
+++ b/ci/setup.sh
@@ -53,6 +53,10 @@ if [[ -n ${GITHUB_ACTIONS-} && -n ${DB-} && x$DB =~ ^xmariadb ]]; then
   sudo apt-get purge -y 'mysql-common*' 'mysql-client*' 'mysql-server*'
   sudo mv /etc/mysql "/etc/mysql-$(date +%Y%m%d-%H%M%S)"
   sudo mv /var/lib/mysql "/var/lib/mysql-$(date +%Y%m%d-%H%M%S)"
+  source /etc/lsb-release
+  sudo apt-get install -y software-properties-common
+  sudo apt-key adv --recv-keys --keyserver keyserver.ubuntu.com 0xF1656F24C74CD1D8
+  sudo add-apt-repository "deb [arch=amd64,arm64,ppc64el] http://sfo1.mirrors.digitalocean.com/mariadb/repo/10.${minor_version}/ubuntu ${DISTRIB_CODENAME} main"
   sudo apt-get install -y -o Dpkg::Options::='--force-confnew' mariadb-server mariadb-server-10.${minor_version} libmariadb-dev
   CHANGED_PASSWORD_BY_RECREATE=true
 fi


### PR DESCRIPTION
Given the upstream version of this gem has few tests on mariadb versions (only 10.3 on ubuntu 18.04), and mariadb 10.3 will soon be out of support (May 2023), this branch is for verifying newer mariadb versions, up to 10.9. Rather than test all combinations, I've added tests for every mariadb minor release between 10.3 and 10.9 (all currently supported releases), on only ubuntu 20.04, and ruby 2.7 (which can be seen happily passing below)

Adding support for 10.4+ required adding the official mariadb package repo's which are hosted on digitalocean. At present the mariadb 10.3 test suite fails starting the database (although it previously passed on the upstream repo), which I believe is due to a clash between the stock ubuntu 10.3 package and the mariadb repo's 10.3 package.